### PR TITLE
fix: ensure projectID parameter is properly handled in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,7 @@
 # Input args
 profile=$1 
 outDir=$2
+projectID=$3
 
 # housekeeping
 if [[ -z $outDir || -z $profile || -z $projectID ]]; then echo "All variables are required: profile outDir projectID"; exit; fi


### PR DESCRIPTION
This PR addresses an issue where the `projectID` parameter was not being handled correctly in the `run.sh` script. 

Changes include:
- Fixed parameter parsing to ensure `projectID` is passed and used properly in the script.

Related issue: #1 
